### PR TITLE
Fix dual tone amplitude bug and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+pytest_cache/

--- a/src/SAME_encode.py
+++ b/src/SAME_encode.py
@@ -24,7 +24,7 @@ def generate_dual_tone(frequency1, frequency2, duration):
     t = np.linspace(0, duration, int(SAMPLE_RATE * duration), endpoint=False)
     signal1 = np.sin(2 * np.pi * frequency1 * t)
     signal2 = np.sin(2 * np.pi * frequency2 * t)
-    dual_tone = signal1 + signal2
+    dual_tone = (signal1 + signal2) / 2
     return dual_tone
 
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,14 @@
+import numpy as np
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from src.SAME_encode import generate_dual_tone, SAMPLE_RATE
+
+def test_dual_tone_amplitude():
+    duration = 1.0
+    tone = generate_dual_tone(1000, 1500, duration)
+    assert np.max(np.abs(tone)) <= 1.0
+    assert len(tone) == int(SAMPLE_RATE * duration)
+


### PR DESCRIPTION
## Summary
- fix amplitude clipping when generating dual-tone signals
- add tests for the audio helper
- add package init and gitignore

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684288adf48c832bb8f2af496e94fa45